### PR TITLE
add header file

### DIFF
--- a/Paging/class/wifi/getgateway.c
+++ b/Paging/class/wifi/getgateway.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 #include <ctype.h>
+#include <stdlib.h>
+#include <sys/sysctl.h>
 #include <netinet/in.h>
 #include <sys/param.h>
 #include "getgateway.h"


### PR DESCRIPTION
一开始缺少头文件，但是添加头文件之后我就遇到了
Undefined symbols for architecture x86_64:
  "_OBJC_CLASS_$_MobClick", referenced from:
      objc-class-ref in SysSettingViewController.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
问题，但是lib是已经添加的，我就把umeng那块代码都给注释掉了，
最后出现缺少resource文件的错误，请问这个如何解决？
